### PR TITLE
Fixes #47: replaced all instances of "elgg-ajaxify" with simply "ajaxify"

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * elgg-ajaxify English language file
+ * ajaxify English language file
  */
 
 $english = array(

--- a/start.php
+++ b/start.php
@@ -19,12 +19,12 @@ function ajaxify_init() {
 	$cached_url = elgg_get_simplecache_url('js', 'pagination_ajaxify');
 	elgg_register_js('elgg.ajaxify.pagination', $cached_url, 'footer');
 	
-	elgg_register_js('jquery.livequery', 'mod/elgg-ajaxify/vendors/livequery/jquery.livequery.js', 'footer');
-	elgg_register_js('jquery.URLParser', 'mod/elgg-ajaxify/vendors/jQuery-URL-Parser/jquery.url.js', 'footer');
-	elgg_register_js('jquery.autocomplete.html_extension', 'mod/elgg-ajaxify/vendors/jQuery-ui/jquery-ui-autocomplete-html-extension/jquery.ui.autocomplete.html.js', 'footer');
+	elgg_register_js('jquery.livequery', 'mod/ajaxify/vendors/livequery/jquery.livequery.js', 'footer');
+	elgg_register_js('jquery.URLParser', 'mod/ajaxify/vendors/jQuery-URL-Parser/jquery.url.js', 'footer');
+	elgg_register_js('jquery.autocomplete.html_extension', 'mod/ajaxify/vendors/jQuery-ui/jquery-ui-autocomplete-html-extension/jquery.ui.autocomplete.html.js', 'footer');
 
 	//Register css
-	elgg_register_css('jquery.ui', 'mod/elgg-ajaxify/vendors/jQuery-ui/css/overcast/jquery-ui-1.8.14.custom.css');
+	elgg_register_css('jquery.ui', 'mod/ajaxify/vendors/jQuery-ui/css/overcast/jquery-ui-1.8.14.custom.css');
 	//Extend the default javascript views
 	elgg_extend_view('js/thewire', 'js/thewire_ajaxify');
 


### PR DESCRIPTION
When the plugin is installed, it's meant to be installed as "ajaxify".
